### PR TITLE
fix: Proper version for the built, respectively released binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           go-version: 1.22.5
       - name: Build
-        run: CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -trimpath -ldflags="-buildid= -w -s -X github.com/arch-go/arch-go/internal.common.version.Version=${{ github.sha }}" -o ./build/
+        run: CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -trimpath -ldflags="-buildid= -w -s -X github.com/arch-go/arch-go/internal.common.Version=${{ github.sha }}" -o ./build/
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         if: github.ref == 'refs/heads/main'
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ builds:
       - -buildid=
       - -w
       - -s
-      - -X github.com/arch-go/arch-go/internal.common.version.Version={{ .Tag }}
+      - -X github.com/arch-go/arch-go/internal.common.Version={{ .Tag }}
     flags:
       - -trimpath
     goos:


### PR DESCRIPTION
## Related issue(s)

closes #110 

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.


## Description

This PR fixes the version information embedded into the binary. For released versions `arch-go --version`  now returns the tag value and for non released versions, it returns the git sha value