### PR TITLE
fix: avoid panic when a package selector compiles to an invalid regexp

### DIFF
--- a/internal/verifications/contents/verifications.go
+++ b/internal/verifications/contents/verifications.go
@@ -32,7 +32,11 @@ func CheckRule(moduleInfo model.ModuleInfo, contentsRule configuration.ContentsR
 		Passes:      true,
 	}
 
-	packageRegExp, _ := regexp.Compile(text.PreparePackageRegexp(contentsRule.Package))
+	packageRegExp, err := regexp.Compile(text.PreparePackageRegexp(contentsRule.Package))
+	if err != nil {
+		return result
+	}
+
 	for _, it := range moduleInfo.Packages {
 		if it != nil && packageRegExp.MatchString(it.Path) {
 			contents, _ := retrieveContents(it)

--- a/internal/verifications/dependencies/verifications.go
+++ b/internal/verifications/dependencies/verifications.go
@@ -32,7 +32,11 @@ func CheckRule(moduleInfo model.ModuleInfo, rule configuration.DependenciesRule)
 		Passes:      true,
 	}
 
-	packageRegExp, _ := regexp.Compile(text.PreparePackageRegexp(rule.Package))
+	packageRegExp, err := regexp.Compile(text.PreparePackageRegexp(rule.Package))
+	if err != nil {
+		return result
+	}
+
 	for _, it := range moduleInfo.Packages {
 		if it != nil && packageRegExp.MatchString(it.Path) {
 			pass, details := checkDependencies(it, rule, moduleInfo)

--- a/internal/verifications/dependencies/verifications_test.go
+++ b/internal/verifications/dependencies/verifications_test.go
@@ -1,0 +1,30 @@
+package dependencies
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/arch-go/arch-go/v2/api/configuration"
+	"github.com/arch-go/arch-go/v2/internal/model"
+)
+
+func TestCheckRuleWithInvalidPackageSelector(t *testing.T) {
+	moduleInfo := model.ModuleInfo{
+		MainPackage: "example.com/repro",
+		Packages: []*model.PackageInfo{
+			{Path: "example.com/repro/a"},
+		},
+	}
+	rule := configuration.DependenciesRule{
+		Package: "example.com/repro/**",
+		ShouldNotDependsOn: &configuration.Dependencies{
+			Internal: []string{"example.com/repro/forbidden"},
+		},
+	}
+
+	result := CheckRule(moduleInfo, rule)
+
+	assert.True(t, result.Passes)
+	assert.Empty(t, result.Verifications)
+}

--- a/internal/verifications/functions/verifications.go
+++ b/internal/verifications/functions/verifications.go
@@ -32,7 +32,11 @@ func CheckRule(moduleInfo model.ModuleInfo, functionRule configuration.Functions
 		Passes:      true,
 	}
 
-	packageRegExp, _ := regexp.Compile(text.PreparePackageRegexp(functionRule.Package))
+	packageRegExp, err := regexp.Compile(text.PreparePackageRegexp(functionRule.Package))
+	if err != nil {
+		return result
+	}
+
 	for _, it := range moduleInfo.Packages {
 		if it != nil && packageRegExp.MatchString(it.Path) {
 			functions, _ := RetrieveFunctions(it, moduleInfo.MainPackage)

--- a/internal/verifications/naming/utils.go
+++ b/internal/verifications/naming/utils.go
@@ -78,7 +78,10 @@ func resolveStructName(ft *ast.FuncDecl) string {
 }
 
 func packageMustBeAnalyzed(pkg *model.PackageInfo, packagePattern string) bool {
-	packageRegExp, _ := regexp.Compile(text.PreparePackageRegexp(packagePattern))
+	packageRegExp, err := regexp.Compile(text.PreparePackageRegexp(packagePattern))
+	if err != nil {
+		return false
+	}
 
 	return pkg != nil && packageRegExp.MatchString(pkg.Path)
 }

--- a/internal/verifications/naming/verifications.go
+++ b/internal/verifications/naming/verifications.go
@@ -37,7 +37,11 @@ func CheckRule(moduleInfo model.ModuleInfo, rule configuration.NamingRule) *Rule
 		Passes:      true,
 	}
 
-	packageRegExp, _ := regexp.Compile(text.PreparePackageRegexp(rule.Package))
+	packageRegExp, err := regexp.Compile(text.PreparePackageRegexp(rule.Package))
+	if err != nil {
+		return result
+	}
+
 	for _, it := range moduleInfo.Packages {
 		if it != nil && packageRegExp.MatchString(it.Path) {
 			pass, details := checkNamingRule(it, rule, moduleInfo)


### PR DESCRIPTION
## Related issue(s)
Fixes #269

## Description
`CheckRule` discards the error from `regexp.Compile`, so a `package` selector that prepares to an invalid pattern (for example a literal `**` as in `example.com/repro/**`) leaves `packageRegExp` nil and the following `MatchString` call panics with a nil-pointer dereference. The same `packageRegExp, _ := regexp.Compile(...)` pattern is repeated in the dependencies, functions, contents and naming verifications, so I checked the error in each and skip the rule (treating an uncompilable selector as matching no package) instead of crashing.

Added a regression test in the dependencies package that reproduces the original panic.

## Checklist
- [x] I agree to follow this project's Code of Conduct.
- [x] I have read, and I am following this repository's Contributing Guidelines.
- [x] I have read the Security Policy.
- [x] I have referenced an issue describing the bug.
- [x] I have added tests that prove the correctness of my implementation.
- [ ] I have updated the documentation.